### PR TITLE
Build fixes

### DIFF
--- a/free95/makefile
+++ b/free95/makefile
@@ -31,15 +31,15 @@ all: $(COBJ) $(ASMOBJ) link run
 
 link:
 	mkdir -p $(BIN)
-	ld $(LDFLAGS) -o $(BIN)/nxoskrnl.nef $(SOURCES)
+	ld $(LDFLAGS) -o $(BIN)/nxoskrnl.nef $(ASMOBJ) $(COBJ)
 
 $(OBJ)/%.s.o: $(SRC)/**.s
 	mkdir -p $(dir $@)
-	nasm $(ASFLAGS) $< -o $@
+	nasm $(ASFLAGS) src/$*.s -o $@
 
 $(OBJ)/%.c.o: $(SRC)/**.c
 	mkdir -p $(dir $@)
-	$(CC) -c $(CFLAGS) $< -o $@
+	$(CC) -c $(CFLAGS) src/$*.c -o $@
 
 run:
 	qemu-system-i386 -kernel $(BIN)/nxoskrnl.nef

--- a/free95/src/interrupt.s
+++ b/free95/src/interrupt.s
@@ -29,7 +29,8 @@
     push byte %2
     jmp irq_common_stub
 %endmacro
-        
+
+ 
 ISR_NOERRCODE 0
 ISR_NOERRCODE 1
 ISR_NOERRCODE 2

--- a/free95/src/kernel.c
+++ b/free95/src/kernel.c
@@ -950,6 +950,9 @@ void mousedrv()
 #define MOUSE_COMMAND_PORT 0x64
 #define MOUSE_DATA_PORT    0x60
 
+// extern void mouse_write(uint8_t data); // mouse.c
+// extern uint8_t mouse_read(); // mouse.c
+
 void mouse_write(uint8_t data) {
     // Wait for the command port to be ready
     while ((inb(MOUSE_COMMAND_PORT) & 0x02) != 0);

--- a/free95/src/mouse.c
+++ b/free95/src/mouse.c
@@ -46,20 +46,24 @@ void mouse_wait(bool type) {
         }
     }
 }
+extern void mouse_write(uint8_t data);
+extern uint8_t mouse_read();
 
-void mouse_write(uint8_t data) {
-    // sending write command
-    mouse_wait(true);
-    outb(PS2_CMD_PORT, 0xD4);
-    mouse_wait(true);
-    // finally write data to port
-    outb(MOUSE_DATA_PORT, data);
-}
 
-uint8_t mouse_read() {
-    mouse_wait(false);
-    return inb(MOUSE_DATA_PORT);
-}
+// this mouse read/write casued wack behavure in qemu
+// void mouse_write(uint8_t data) {
+//     // sending write command
+//     mouse_wait(true);
+//     outb(PS2_CMD_PORT, 0xD4);
+//     mouse_wait(true);
+//     // finally write data to port
+//     outb(MOUSE_DATA_PORT, data);
+// }
+
+// uint8_t mouse_read() {
+//     mouse_wait(false);
+//     return inb(MOUSE_DATA_PORT);
+// }
 
 void get_mouse_status(uint8_t status_byte, MOUSE_STATUS *status) {
     memset(status, 0, sizeof(MOUSE_STATUS));

--- a/free95/src/string.c
+++ b/free95/src/string.c
@@ -30,7 +30,7 @@ void memcpy(uint8_t *dest, const uint8_t *src, uint32_t len)
 }
 
 // Write len copies of val into dest.
-void memset(uint8_t *dest, uint8_t val, uint32_t len)
+void memset(void *dest, uint8_t val, uint32_t len)
 {
     uint8_t *temp = (uint8_t *)dest;
     for ( ; len != 0; len--) *temp++ = val;

--- a/free95/src/string.h
+++ b/free95/src/string.h
@@ -7,7 +7,7 @@ void outb(uint16_t port, uint8_t value);
 
 void memcpy(uint8_t *dest, const uint8_t *src, uint32_t len);
 
-void memset(uint8_t *dest, uint8_t val, uint32_t len);
+void memset(void *dest, uint8_t val, uint32_t len);
 
 int strcmp(char *str1, char *str2);
 char *strcpy(char *dest, const char *src);


### PR DESCRIPTION
I was having issues where the make file was just building the descriptorTable.c and naming it as the name of the input file, I fixed that so now it actually builds and runs.

I also commented out a definition of the mouse read/mouse write, so that we can compile 

I Also fixed the build warnings about passing the wrong times into memset. Users of memset don't care that we operate on the data at the pointer as a u8 

Feel free to close this if it's not up to your standards or not how you want to handle this 😄 

![image](https://github.com/user-attachments/assets/d6fae6d3-18e0-4684-aaf5-11d125dfdba9)

